### PR TITLE
Oversized bag tests

### DIFF
--- a/include/ygm/container/oversized_bag.hpp
+++ b/include/ygm/container/oversized_bag.hpp
@@ -160,7 +160,6 @@ class oversized_bag : public detail::base_async_insert_value<oversized_bag<Item>
       while(m_file_io.peek() != EOF) {
         Item temp;
         iarchive(temp);
-        std::cout << temp << std::endl;
         storage.push_back(temp);
       }
       //YGM_ASSERT_RELEASE(storage.size() == m_size);
@@ -221,7 +220,7 @@ class oversized_bag : public detail::base_async_insert_value<oversized_bag<Item>
     bool                            m_active;
     file_base_info                 &m_file_info;
    public:
-    std::fstream                    &m_file_io;
+    std::fstream                    m_file_io;
 
   };
   

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_ygm_test(test_recursion_progress)
 add_ygm_test(test_gather_topk)
 add_ygm_test(test_reduce)
 add_ygm_test(test_transform)
+add_ygm_test(test_oversized_bag)
 
 if (Boost_FOUND)
     add_ygm_seq_test(test_cereal_boost_json)

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -34,92 +34,13 @@ int main(int argc, char** argv) {
       bbag.async_insert("apple");
       bbag.async_insert("red");
     }
+    world.barrier();
     // Count and size functions come from overarching ygm container,
     // rely on local functions
+    std::cout << "Dog count: " << bbag.count("dog") << std::endl;
     YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
     YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
     YGM_ASSERT_RELEASE(bbag.count("red") == 1);
     YGM_ASSERT_RELEASE(bbag.size() == 3);
   }
-
-  // 
-
-  // Currently, shuffle functions are being ignored as per Roger
-  // Test local_shuffle and global_shuffle
-  // {
-  //   ygm::container::oversized_bag<int> bbag(world);
-  // 
-  // }
-
-  // 
-  // Test for_all
-  {
-    ygm::container::oversized_bag<std::string> bbag(world);
-    if (world.rank0()) {
-      bbag.async_insert("dog");
-      bbag.async_insert("apple");
-      bbag.async_insert("red");
-    }
-    int count{0};
-    bbag.for_all([&count](std::string& mstr) { ++count; });
-    int global_count = world.all_reduce_sum(count);
-    world.barrier();
-    YGM_ASSERT_RELEASE(global_count == 3);
-  }
-
-  //
-  // Test for_all (pair)
-  {
-    ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
-    if (world.rank0()) {
-      pbag.async_insert({"dog", 1});
-      pbag.async_insert({"apple", 2});
-      pbag.async_insert({"red", 3});
-    }
-    int count{0};
-    pbag.for_all(
-      [&count] (std::pair<std::string, int>& mstr) { count += mstr.second; });
-    int global_count = world.all_reduce_sum(count);
-    world.barrier();
-    YGM_ASSERT_RELEASE(global_count == 6);
-  }
-
-  //
-  // Test for_all (split pair)
-  // {
-  //   ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
-  //   if (world.rank0()) {
-  //     pbag.async_insert({"dog"}, 1);
-  //     pbag.async_insert({"apple"}, 2);
-  //     pbag.async_insert({"red"}, 3);
-  //   }
-  //   int count{0};
-  //   pbag.for_all(
-  //     [&count](std::string& first, int& second) { count += second; });
-  //   int global_count = world.all_reduce_sum(count);
-  //   world.barrier();
-  //   YGM_ASSERT_RELEASE(global_count == 6);
-  // }
-
-  //
-  // Test rebalance
-  {
-    ygm::container::oversized_bag<std::string> bbag(world);
-
-  }
-
-  //
-  // Test rebalance with non-standard rebalance sizes
-  {
-    ygm::container::oversized_bag<std::string> bbag(world);
-
-  }
-
-  //
-  // Test output data after rebalance
-  {
-    ygm::container::oversized_bag<int> bbag(world);
-
-  }
-
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -37,10 +37,125 @@ int main(int argc, char** argv) {
     world.barrier();
     // Count and size functions come from overarching ygm container,
     // rely on local functions
-    std::cout << "Dog count: " << bbag.count("dog") << std::endl;
-    YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
-    YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
-    YGM_ASSERT_RELEASE(bbag.count("red") == 1);
-    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    //std::cout << "Dog: " << bbag.count("dog") << std::endl;
+    //YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
+    // YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
+    // YGM_ASSERT_RELEASE(bbag.count("red") == 1);
+    // YGM_ASSERT_RELEASE(bbag.size() == 3);
+    // bbag.clear();
   }
+
+  //
+  // Test Rank 0 local insert on addition past file threshold
+  // {
+  //   size_t threshold = 1;
+  //   ygm::container::oversized_bag<std::string> bbag = ygm::container::oversized_bag<std::string>(world, threshold);
+  //   if (world.rank0()) {
+  //     bbag.local_insert("dog");
+  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 1);
+  //     bbag.local_insert("apple");
+  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 2);
+  //     bbag.local_insert("red");
+  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 3);
+  //   }
+  //   world.barrier();
+  //   
+  //   // Count and size functions come from overarching ygm container,
+  //   // rely on local functions
+  //   YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
+  //   YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
+  //   YGM_ASSERT_RELEASE(bbag.count("red") == 1);
+  //   YGM_ASSERT_RELEASE(bbag.size() == 3);
+  //   bbag.clear();
+  // }
+
+
+  //
+  // Test Rebalance
+  // {
+  //   ygm::container::oversized_bag<std::string> bbag(world);
+  //   bbag.async_insert("begin", 0);
+  //   bbag.async_insert("end", world.size() - 1);
+  //   bbag.rebalance();
+  //   YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+  // }
+
+  // Currently, shuffle functions are being ignored as per Roger
+  // Test local_shuffle and global_shuffle
+  // {
+  //   ygm::container::oversized_bag<int> bbag(world);
+  // 
+  // }
+
+  // 
+  // Test for_all
+  // {
+  //   ygm::container::oversized_bag<std::string> bbag(world);
+  //   if (world.rank0()) {
+  //     bbag.async_insert("dog");
+  //     bbag.async_insert("apple");
+  //     bbag.async_insert("red");
+  //   }
+  //   int count{0};
+  //   bbag.for_all([&count](std::string& mstr) { ++count; });
+  //   int global_count = world.all_reduce_sum(count);
+  //   world.barrier();
+  //   YGM_ASSERT_RELEASE(global_count == 3);
+  // }
+
+  //
+  // Test for_all (pair)
+  // {
+  //   ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+  //   if (world.rank0()) {
+  //     pbag.async_insert({"dog", 1});
+  //     pbag.async_insert({"apple", 2});
+  //     pbag.async_insert({"red", 3});
+  //   }
+  //   int count{0};
+  //   pbag.for_all(
+  //     [&count] (std::pair<std::string, int>& mstr) { count += mstr.second; });
+  //   int global_count = world.all_reduce_sum(count);
+  //   world.barrier();
+  //   YGM_ASSERT_RELEASE(global_count == 6);
+  // }
+
+  //
+  // Test for_all (split pair)
+  // {
+  //   ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+  //   if (world.rank0()) {
+  //     pbag.async_insert({"dog"}, 1);
+  //     pbag.async_insert({"apple"}, 2);
+  //     pbag.async_insert({"red"}, 3);
+  //   }
+  //   int count{0};
+  //   pbag.for_all(
+  //     [&count](std::string& first, int& second) { count += second; });
+  //   int global_count = world.all_reduce_sum(count);
+  //   world.barrier();
+  //   YGM_ASSERT_RELEASE(global_count == 6);
+  // }
+
+  //
+  // Test rebalance
+  // {
+  //   ygm::container::oversized_bag<std::string> bbag(world);
+  // 
+  // }
+
+  //
+  // Test rebalance with non-standard rebalance sizes
+  // {
+  //   ygm::container::oversized_bag<std::string> bbag(world);
+  // 
+  // }
+
+  //
+  // Test output data after rebalance
+  // {
+  //   ygm::container::oversized_bag<int> bbag(world);
+  // 
+  // }
+
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -42,12 +42,14 @@ int main(int argc, char** argv) {
     YGM_ASSERT_RELEASE(bbag.size() == 3);
   }
 
-  // TODO: Currently, shuffle functions are being ignored as per Ryan
-  // Test local_shuffle and global_shuffle
-  {
-    ygm::container::oversized_bag<int> bbag(world);
+  // 
 
-  }
+  // Currently, shuffle functions are being ignored as per Roger
+  // Test local_shuffle and global_shuffle
+  // {
+  //   ygm::container::oversized_bag<int> bbag(world);
+  // 
+  // }
 
   // 
   // Test for_all
@@ -84,20 +86,20 @@ int main(int argc, char** argv) {
 
   //
   // Test for_all (split pair)
-  {
-    ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
-    if (world.rank0()) {
-      pbag.async_insert({"dog"}, 1);
-      pbag.async_insert({"apple"}, 2);
-      pbag.async_insert({"red"}, 3);
-    }
-    int count{0};
-    pbag.for_all(
-      [&count](std::string& first, int& second) { count += second; });
-    int global_count = world.all_reduce_sum(count);
-    world.barrier();
-    YGM_ASSERT_RELEASE(global_count == 6);
-  }
+  // {
+  //   ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+  //   if (world.rank0()) {
+  //     pbag.async_insert({"dog"}, 1);
+  //     pbag.async_insert({"apple"}, 2);
+  //     pbag.async_insert({"red"}, 3);
+  //   }
+  //   int count{0};
+  //   pbag.for_all(
+  //     [&count](std::string& first, int& second) { count += second; });
+  //   int global_count = world.all_reduce_sum(count);
+  //   world.barrier();
+  //   YGM_ASSERT_RELEASE(global_count == 6);
+  // }
 
   //
   // Test rebalance

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -137,25 +137,61 @@ int main(int argc, char** argv) {
   //   YGM_ASSERT_RELEASE(global_count == 6);
   // }
 
-  //
+/*
   // Test rebalance
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  // 
-  // }
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    bbag.async_insert("begin", 0);
+    bbag.async_insert("end", world.size() - 1);
+    bbag.rebalance();
+    YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+  }
 
   //
   // Test rebalance with non-standard rebalance sizes
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  // 
-  // }
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    bbag.async_insert("middle", world.size() / 2);
+    bbag.async_insert("end", world.size() - 1);
+    if (world.rank0()) bbag.async_insert("middle", world.size() / 2);
+    bbag.rebalance();
+
+    size_t target_size      = std::ceil((bbag.size() * 1.0) / world.size());
+    size_t remainder        = bbag.size() % world.size();
+    size_t small_block_size = bbag.size() / world.size();
+    size_t large_block_size =
+        bbag.size() / world.size() + (bbag.size() % world.size() > 0);
+
+    if (world.rank() < remainder) {
+      YGM_ASSERT_RELEASE(bbag.local_size() == large_block_size);
+    } else {
+      YGM_ASSERT_RELEASE(bbag.local_size() == small_block_size);
+    }
+  }
 
   //
   // Test output data after rebalance
-  // {
-  //   ygm::container::oversized_bag<int> bbag(world);
-  // 
-  // }
+  {
+    ygm::container::oversized_bag<int> bbag(world);
+    if (world.rank0()) {
+      for (int i = 0; i < 100; i++) {
+        bbag.async_insert(i, (i * 3) % world.size());
+      }
+      for (int i = 100; i < 200; i++) {
+        bbag.async_insert(i, (i * 5) % world.size());
+      }
+    }
+    bbag.rebalance();
+
+    std::set<int> value_set;
+    bbag.gather(value_set, 0);
+    if (world.rank0()) {
+      YGM_ASSERT_RELEASE(value_set.size() == 200);
+      YGM_ASSERT_RELEASE(*std::min_element(value_set.begin(), value_set.end()) ==
+                     0);
+      YGM_ASSERT_RELEASE(*std::max_element(value_set.begin(), value_set.end()) ==
+                     199);
+    }
+  }*/
 
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -93,16 +93,7 @@ int main(int argc, char** argv) {
         YGM_ASSERT_RELEASE(all_data.size() == 3);
       }
     }
-  }
-
-  //
-  // Test Rebalance
-  {
-    ygm::container::oversized_bag<std::string> bbag(world);
-    bbag.async_insert("begin", 0);
-    bbag.async_insert("end", world.size() - 1);
-    bbag.rebalance();
-    YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+    bbag.clear();
   }
 
   // Currently, shuffle functions are being ignored as per Roger
@@ -126,6 +117,7 @@ int main(int argc, char** argv) {
     int global_count = world.all_reduce_sum(count);
     world.barrier();
     YGM_ASSERT_RELEASE(global_count == 3);
+    bbag.clear();
   }
 
   //
@@ -143,6 +135,7 @@ int main(int argc, char** argv) {
     int global_count = world.all_reduce_sum(count);
     world.barrier();
     YGM_ASSERT_RELEASE(global_count == 6);
+    bbag.clear();
   }
 
   //
@@ -170,6 +163,7 @@ int main(int argc, char** argv) {
     bbag.async_insert("end", world.size() - 1);
     bbag.rebalance();
     YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+    bbag.clear();
   }
 
   //
@@ -192,6 +186,7 @@ int main(int argc, char** argv) {
     } else {
       YGM_ASSERT_RELEASE(bbag.local_size() == small_block_size);
     }
+    bbag.clear();
   }
 
   //
@@ -217,6 +212,7 @@ int main(int argc, char** argv) {
       YGM_ASSERT_RELEASE(*std::max_element(value_set.begin(), value_set.end()) ==
                      199);
     }
+    bbag.clear();
   }
 
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -18,42 +18,85 @@ int main(int argc, char** argv) {
   // Test basic tagging
   {
     ygm::container::oversized_bag<std::string> bbag(world);
-
+    static_assert(std::is_same_v<decltype(bbag)::self_type, decltype(bbag)>);
+    static_assert(std::is_same_v<decltype(bbag)::value_type, std::string>);
+    static_assert(std::is_same_v<decltype(bbag)::size_type, size_t>);
+    static_assert(std::is_same_v<decltype(bbag)::for_all_args,
+                                 std::tuple<decltype(bbag)::value_type>>);
   }
 
   //
   // Test Rank 0 async_insert
   {
     ygm::container::oversized_bag<std::string> bbag(world);
-
+    if (world.rank0()) {
+      bbag.async_insert("dog");
+      bbag.async_insert("apple");
+      bbag.async_insert("red");
+    }
+    // Count and size functions come from overarching ygm container,
+    // rely on local functions
+    YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
+    YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
+    YGM_ASSERT_RELEASE(bbag.count("red") == 1);
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
   }
 
-  //
+  // TODO: Currently, shuffle functions are being ignored as per Ryan
   // Test local_shuffle and global_shuffle
   {
     ygm::container::oversized_bag<int> bbag(world);
 
   }
 
-  //
+  // 
   // Test for_all
   {
     ygm::container::oversized_bag<std::string> bbag(world);
-
+    if (world.rank0()) {
+      bbag.async_insert("dog");
+      bbag.async_insert("apple");
+      bbag.async_insert("red");
+    }
+    int count{0};
+    bbag.for_all([&count](std::string& mstr) { ++count; });
+    int global_count = world.all_reduce_sum(count);
+    world.barrier();
+    YGM_ASSERT_RELEASE(global_count == 3);
   }
 
   //
   // Test for_all (pair)
   {
     ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
-
+    if (world.rank0()) {
+      pbag.async_insert({"dog", 1});
+      pbag.async_insert({"apple", 2});
+      pbag.async_insert({"red", 3});
+    }
+    int count{0};
+    pbag.for_all(
+      [&count] (std::pair<std::string, int>& mstr) { count += mstr.second; });
+    int global_count = world.all_reduce_sum(count);
+    world.barrier();
+    YGM_ASSERT_RELEASE(global_count == 6);
   }
 
   //
   // Test for_all (split pair)
   {
-    ygm::container::bag<std::pair<std::string, int>> pbag(world);
-  
+    ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+    if (world.rank0()) {
+      pbag.async_insert({"dog"}, 1);
+      pbag.async_insert({"apple"}, 2);
+      pbag.async_insert({"red"}, 3);
+    }
+    int count{0};
+    pbag.for_all(
+      [&count](std::string& first, int& second) { count += second; });
+    int global_count = world.all_reduce_sum(count);
+    world.barrier();
+    YGM_ASSERT_RELEASE(global_count == 6);
   }
 
   //

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -47,38 +47,38 @@ int main(int argc, char** argv) {
 
   //
   // Test Rank 0 local insert on addition past file threshold
-  // {
-  //   size_t threshold = 1;
-  //   ygm::container::oversized_bag<std::string> bbag = ygm::container::oversized_bag<std::string>(world, threshold);
-  //   if (world.rank0()) {
-  //     bbag.local_insert("dog");
-  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 1);
-  //     bbag.local_insert("apple");
-  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 2);
-  //     bbag.local_insert("red");
-  //     YGM_ASSERT_RELEASE(bbag.num_local_files() == 3);
-  //   }
-  //   world.barrier();
-  //   
-  //   // Count and size functions come from overarching ygm container,
-  //   // rely on local functions
-  //   YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
-  //   YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
-  //   YGM_ASSERT_RELEASE(bbag.count("red") == 1);
-  //   YGM_ASSERT_RELEASE(bbag.size() == 3);
-  //   bbag.clear();
-  // }
+  {
+    size_t threshold = 1;
+    ygm::container::oversized_bag<std::string> bbag = ygm::container::oversized_bag<std::string>(world, threshold);
+    if (world.rank0()) {
+      bbag.local_insert("dog");
+      YGM_ASSERT_RELEASE(bbag.num_local_files() == 1);
+      bbag.local_insert("apple");
+      YGM_ASSERT_RELEASE(bbag.num_local_files() == 2);
+      bbag.local_insert("red");
+      YGM_ASSERT_RELEASE(bbag.num_local_files() == 3);
+    }
+    world.barrier();
+    
+    // Count and size functions come from overarching ygm container,
+    // rely on local functions
+    YGM_ASSERT_RELEASE(bbag.count("dog") == 1);
+    YGM_ASSERT_RELEASE(bbag.count("apple") == 1);
+    YGM_ASSERT_RELEASE(bbag.count("red") == 1);
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    bbag.clear();
+  }
 
 
   //
   // Test Rebalance
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  //   bbag.async_insert("begin", 0);
-  //   bbag.async_insert("end", world.size() - 1);
-  //   bbag.rebalance();
-  //   YGM_ASSERT_RELEASE(bbag.local_size() == 2);
-  // }
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    bbag.async_insert("begin", 0);
+    bbag.async_insert("end", world.size() - 1);
+    bbag.rebalance();
+    YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+  }
 
   // Currently, shuffle functions are being ignored as per Roger
   // Test local_shuffle and global_shuffle
@@ -89,36 +89,36 @@ int main(int argc, char** argv) {
 
   // 
   // Test for_all
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  //   if (world.rank0()) {
-  //     bbag.async_insert("dog");
-  //     bbag.async_insert("apple");
-  //     bbag.async_insert("red");
-  //   }
-  //   int count{0};
-  //   bbag.for_all([&count](std::string& mstr) { ++count; });
-  //   int global_count = world.all_reduce_sum(count);
-  //   world.barrier();
-  //   YGM_ASSERT_RELEASE(global_count == 3);
-  // }
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    if (world.rank0()) {
+      bbag.async_insert("dog");
+      bbag.async_insert("apple");
+      bbag.async_insert("red");
+    }
+    int count{0};
+    bbag.for_all([&count](std::string& mstr) { ++count; });
+    int global_count = world.all_reduce_sum(count);
+    world.barrier();
+    YGM_ASSERT_RELEASE(global_count == 3);
+  }
 
   //
   // Test for_all (pair)
-  // {
-  //   ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
-  //   if (world.rank0()) {
-  //     pbag.async_insert({"dog", 1});
-  //     pbag.async_insert({"apple", 2});
-  //     pbag.async_insert({"red", 3});
-  //   }
-  //   int count{0};
-  //   pbag.for_all(
-  //     [&count] (std::pair<std::string, int>& mstr) { count += mstr.second; });
-  //   int global_count = world.all_reduce_sum(count);
-  //   world.barrier();
-  //   YGM_ASSERT_RELEASE(global_count == 6);
-  // }
+  {
+    ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+    if (world.rank0()) {
+      pbag.async_insert({"dog", 1});
+      pbag.async_insert({"apple", 2});
+      pbag.async_insert({"red", 3});
+    }
+    int count{0};
+    pbag.for_all(
+      [&count] (std::pair<std::string, int>& mstr) { count += mstr.second; });
+    int global_count = world.all_reduce_sum(count);
+    world.barrier();
+    YGM_ASSERT_RELEASE(global_count == 6);
+  }
 
   //
   // Test for_all (split pair)
@@ -136,26 +136,4 @@ int main(int argc, char** argv) {
   //   world.barrier();
   //   YGM_ASSERT_RELEASE(global_count == 6);
   // }
-
-  //
-  // Test rebalance
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  // 
-  // }
-
-  //
-  // Test rebalance with non-standard rebalance sizes
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  // 
-  // }
-
-  //
-  // Test output data after rebalance
-  // {
-  //   ygm::container::oversized_bag<int> bbag(world);
-  // 
-  // }
-
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -164,39 +164,39 @@ int main(int argc, char** argv) {
 
 
   // Test rebalance
-  // {
-  //   ygm::container::oversized_bag<std::string> bbag(world);
-  //   bbag.async_insert("begin", 0);
-  //   bbag.async_insert("end", world.size() - 1);
-  //   bbag.rebalance();
-  //   YGM_ASSERT_RELEASE(bbag.local_size() == 2);
-  // }
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    bbag.async_insert("begin", 0);
+    bbag.async_insert("end", world.size() - 1);
+    bbag.rebalance();
+    YGM_ASSERT_RELEASE(bbag.local_size() == 2);
+  }
 
   //
   // Test rebalance with non-standard rebalance sizes
-  //{
-  //  ygm::container::oversized_bag<std::string> bbag(world);
-  //  bbag.async_insert("middle", world.size() / 2);
-  //  bbag.async_insert("end", world.size() - 1);
-  //  if (world.rank0()) bbag.async_insert("middle", world.size() / 2);
-  //  bbag.rebalance();
-//
-  //  size_t target_size      = std::ceil((bbag.size() * 1.0) / world.size());
-  //  size_t remainder        = bbag.size() % world.size();
-  //  size_t small_block_size = bbag.size() / world.size();
-  //  size_t large_block_size =
-  //      bbag.size() / world.size() + (bbag.size() % world.size() > 0);
-//
-  //  if (world.rank() < remainder) {
-  //    YGM_ASSERT_RELEASE(bbag.local_size() == large_block_size);
-  //  } else {
-  //    YGM_ASSERT_RELEASE(bbag.local_size() == small_block_size);
-  //  }
-  //}
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+    bbag.async_insert("middle", world.size() / 2);
+    bbag.async_insert("end", world.size() - 1);
+    if (world.rank0()) bbag.async_insert("middle", world.size() / 2);
+    bbag.rebalance();
+
+    size_t target_size      = std::ceil((bbag.size() * 1.0) / world.size());
+    size_t remainder        = bbag.size() % world.size();
+    size_t small_block_size = bbag.size() / world.size();
+    size_t large_block_size =
+        bbag.size() / world.size() + (bbag.size() % world.size() > 0);
+
+    if (world.rank() < remainder) {
+      YGM_ASSERT_RELEASE(bbag.local_size() == large_block_size);
+    } else {
+      YGM_ASSERT_RELEASE(bbag.local_size() == small_block_size);
+    }
+  }
 
   //
   // Test output data after rebalance
-  /* {
+  {
     ygm::container::oversized_bag<int> bbag(world);
     if (world.rank0()) {
       for (int i = 0; i < 100; i++) {
@@ -217,6 +217,6 @@ int main(int argc, char** argv) {
       YGM_ASSERT_RELEASE(*std::max_element(value_set.begin(), value_set.end()) ==
                      199);
     }
-  } */
+  }
 
 }

--- a/test/test_oversized_bag.cpp
+++ b/test/test_oversized_bag.cpp
@@ -1,0 +1,80 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+
+#include <set>
+#include <string>
+#include <vector>
+#include <ygm/comm.hpp>
+#include <ygm/container/oversized_bag.hpp>
+#include <ygm/random.hpp>
+
+int main(int argc, char** argv) {
+  ygm::comm world(&argc, &argv);
+
+  // Test basic tagging
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+
+  }
+
+  //
+  // Test Rank 0 async_insert
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+
+  }
+
+  //
+  // Test local_shuffle and global_shuffle
+  {
+    ygm::container::oversized_bag<int> bbag(world);
+
+  }
+
+  //
+  // Test for_all
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+
+  }
+
+  //
+  // Test for_all (pair)
+  {
+    ygm::container::oversized_bag<std::pair<std::string, int>> pbag(world);
+
+  }
+
+  //
+  // Test for_all (split pair)
+  {
+    ygm::container::bag<std::pair<std::string, int>> pbag(world);
+  
+  }
+
+  //
+  // Test rebalance
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+
+  }
+
+  //
+  // Test rebalance with non-standard rebalance sizes
+  {
+    ygm::container::oversized_bag<std::string> bbag(world);
+
+  }
+
+  //
+  // Test output data after rebalance
+  {
+    ygm::container::oversized_bag<int> bbag(world);
+
+  }
+
+}


### PR DESCRIPTION
## Description
Initial implementation of tests corresponding to the oversized bag data structure.

## Changes in the codebase
Created some tests for a variety of functions pertaining to the oversized bag. Mainly, created tests for the following features:

- Basic tagging #23 
- Rank 0 async_insert #24 
- for_all #27 
- for_all (pair) #28 
- for_all (split pair) #29 

Additionally, created skeletons for the following tests that will be getting implemented at a later point in time:
- rebalance #30 
- rebalance with non-standard rebalance sizes #31 

Something to note as well is that the shuffle functions (#26) are not implemented for now.

## Additional Information
A lot of the tests outlined here are very similar to the original bag tests. I don't expect everything here to be correct on the first try, and would appreciate any input on how it should be changed.